### PR TITLE
fix README.md usage section

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Install ciak
 Launch the media server (on 0.0.0.0:8082)
 
 
-    ciak --data=<your/media/directory>
+    ciak --media=<your/media/directory>
 
 
 


### PR DESCRIPTION
Hi GaruGaru!
there is a mistake in README.md, the parameter is `--media`  not `--data`

```sh
./ciak --data d:\\videos
Error: unknown flag: --data

./ciak --media d:\\videos
time="2020-11-19T17:28:31+08:00" level=info msg="Ciak daemon started" queue_size=1000 workers=2
time="2020-11-19T17:28:31+08:00" level=info msg="Ciak server started" bind="0.0.0.0:8082" version=0.0.2
time="2020-11-19T17:29:47+08:00" level=info msg="Found 5 media after discovery"
time="2020-11-19T17:29:47+08:00" level=info msg=/ duration=4
time="2020-11-19T17:29:52+08:00" level=info msg="Found 5 media after discovery"
time="2020-11-19T17:29:52+08:00" level=info msg=/media/4030130426 duration=24
time="2020-11-19T17:29:52+08:00" level=info msg="Found 5 media after discovery"
time="2020-11-19T17:29:54+08:00" level=info msg=/media/4030130426 duration=2414
```
