### PR TITLE
use built-in sync.Map ensure goroutine safe

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .idea/
 vendor/
 dist/
-./ciak
-./ciak_daemon.db
+/ciak
+/ciak.exe
+/ciak_daemon.db

--- a/README.md
+++ b/README.md
@@ -56,4 +56,4 @@ You can configure Ciak using the command line flags
 
 * **--omdb-api-key** omdbapi.com api key used for movie metadata retrieving 
 
-* **--db** database file path (default /tmp/ciak_daemon.db)
+* **--db** database file path (default /ciak_daemon.db)

--- a/pkg/omdb/cache.go
+++ b/pkg/omdb/cache.go
@@ -8,26 +8,22 @@ type Cache interface {
 }
 
 type MemoryCache struct {
-	cacheMap map[string]Movie
-	mutex *sync.RWMutex
-}
-
-func NewMemoryCache() *MemoryCache {
-	return &MemoryCache{
-		cacheMap: make(map[string]Movie),
-		mutex: &sync.RWMutex{},
-	}
+	sync.Map
 }
 
 func (m *MemoryCache) Put(key string, movie Movie) {
-	m.mutex.Lock()
-	defer m.mutex.Unlock()
-	m.cacheMap[key] = movie
+	m.Store(key, movie)
 }
 
 func (m *MemoryCache) Get(key string) (Movie, bool) {
-	m.mutex.RLock()
-	defer m.mutex.RUnlock()
-	movie, present := m.cacheMap[key]
-	return movie, present
+	res, ok := m.Load(key)
+	if ok {
+		return res.(Movie), ok
+	} else {
+		return Movie{}, ok
+	}
+}
+
+func (m *MemoryCache) Del(key string) {
+	m.Delete(key)
 }

--- a/pkg/omdb/cache.go
+++ b/pkg/omdb/cache.go
@@ -11,6 +11,10 @@ type MemoryCache struct {
 	sync.Map
 }
 
+func NewMemoryCache() *MemoryCache {
+	return &MemoryCache{}
+}
+
 func (m *MemoryCache) Put(key string, movie Movie) {
 	m.Store(key, movie)
 }
@@ -19,9 +23,8 @@ func (m *MemoryCache) Get(key string) (Movie, bool) {
 	res, ok := m.Load(key)
 	if ok {
 		return res.(Movie), ok
-	} else {
-		return Movie{}, ok
 	}
+	return Movie{}, ok
 }
 
 func (m *MemoryCache) Del(key string) {

--- a/pkg/omdb/catch_test.go
+++ b/pkg/omdb/catch_test.go
@@ -1,12 +1,11 @@
 package omdb
 
 import (
-	"fmt"
 	"testing"
 )
 
 func TestBasic(t *testing.T) {
-	memCache := &MemoryCache{}
+	memCache := NewMemoryCache()
 	key := "The Queen's Gambit"
 	movie := Movie{
 		Title:    "The Queen's Gambit",
@@ -39,15 +38,15 @@ func TestBasic(t *testing.T) {
 	memCache.Put(key, movie)
 	movie, exist := memCache.Get(key)
 	if !exist {
-		fmt.Println("error, movie doesn't exist")
+		t.Error("error, we store a movie in Cache, but it doesn't exist when we get it")
 	} else {
-		fmt.Println("movie stored and get successful")
+		t.Log("movie stored and get successful")
 	}
 	memCache.Del(key)
 	movie, exist = memCache.Get(key)
 	if exist {
-		fmt.Println("delete failed")
+		t.Error("we delete a movie from cache, but when we get it, it still exists, wired!")
 	} else {
-		fmt.Println("delete successful")
+		t.Log("delete successful")
 	}
 }

--- a/pkg/omdb/catch_test.go
+++ b/pkg/omdb/catch_test.go
@@ -1,0 +1,53 @@
+package omdb
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestBasic(t *testing.T) {
+	memCache := &MemoryCache{}
+	key := "The Queen's Gambit"
+	movie := Movie{
+		Title:    "The Queen's Gambit",
+		Year:     "2020–",
+		Rated:    "TV-MA",
+		Released: "23 Oct 2020",
+		Runtime:  "N/A",
+		Genre:    "Drama",
+		Director: "N/A",
+		Writer:   "N/A",
+		Actors:   "Anya Taylor-Joy, Chloe Pirrie, Bill Camp, Matthew Dennis Lewis",
+		Plot:     "Eight year-old orphan Beth Harmon is quiet, sullen, and by all appearances unremarkable. That is, until she plays her first game of chess. Her senses grow sharper, her thinking clearer, and...",
+		Language: "English",
+		Country:  "USA",
+		Awards:   "N/A",
+		Poster:   "https://m.media-amazon.com/images/M/MV5BM2EwMmRhMmUtMzBmMS00ZDQ3LTg4OGEtNjlkODk3ZTMxMmJlXkEyXkFqcGdeQXVyMjM5ODk1NDU@._V1_SX300.jpg",
+		Ratings: []Rating{
+			{
+				Source: "Internet Movie Database",
+				Value:  "8.9/10",
+			},
+		},
+		Metascore:  "N/A",
+		ImdbRating: "8.9",
+		ImdbVotes:  "6,077",
+		ImdbID:     "tt10048342",
+		Type:       "series",
+		Response:   "True",
+	}
+	memCache.Put(key, movie)
+	movie, exist := memCache.Get(key)
+	if !exist {
+		fmt.Println("error, movie doesn't exist")
+	} else {
+		fmt.Println("movie stored and get successful")
+	}
+	memCache.Del(key)
+	movie, exist = memCache.Get(key)
+	if exist {
+		fmt.Println("delete failed")
+	} else {
+		fmt.Println("delete successful")
+	}
+}

--- a/pkg/omdb/model.go
+++ b/pkg/omdb/model.go
@@ -1,32 +1,34 @@
 package omdb
 
+type Rating struct {
+	Source string `json:"Source"`
+	Value  string `json:"Value"`
+}
+
 type Movie struct {
-	Title    string `json:"Title"`
-	Year     string `json:"Year"`
-	Rated    string `json:"Rated"`
-	Released string `json:"Released"`
-	Runtime  string `json:"Runtime"`
-	Genre    string `json:"Genre"`
-	Director string `json:"Director"`
-	Writer   string `json:"Writer"`
-	Actors   string `json:"Actors"`
-	Plot     string `json:"Plot"`
-	Language string `json:"Language"`
-	Country  string `json:"Country"`
-	Awards   string `json:"Awards"`
-	Poster   string `json:"Poster"`
-	Ratings  []struct {
-		Source string `json:"Source"`
-		Value  string `json:"Value"`
-	} `json:"Ratings"`
-	Metascore  string `json:"Metascore"`
-	ImdbRating string `json:"imdbRating"`
-	ImdbVotes  string `json:"imdbVotes"`
-	ImdbID     string `json:"imdbID"`
-	Type       string `json:"Type"`
-	DVD        string `json:"DVD"`
-	BoxOffice  string `json:"BoxOffice"`
-	Production string `json:"Production"`
-	Website    string `json:"Website"`
-	Response   string `json:"Response"`
+	Title      string   `json:"Title"`
+	Year       string   `json:"Year"`
+	Rated      string   `json:"Rated"`
+	Released   string   `json:"Released"`
+	Runtime    string   `json:"Runtime"`
+	Genre      string   `json:"Genre"`
+	Director   string   `json:"Director"`
+	Writer     string   `json:"Writer"`
+	Actors     string   `json:"Actors"`
+	Plot       string   `json:"Plot"`
+	Language   string   `json:"Language"`
+	Country    string   `json:"Country"`
+	Awards     string   `json:"Awards"`
+	Poster     string   `json:"Poster"`
+	Ratings    []Rating `json:"Ratings"`
+	Metascore  string   `json:"Metascore"`
+	ImdbRating string   `json:"imdbRating"`
+	ImdbVotes  string   `json:"imdbVotes"`
+	ImdbID     string   `json:"imdbID"`
+	Type       string   `json:"Type"`
+	DVD        string   `json:"DVD"`
+	BoxOffice  string   `json:"BoxOffice"`
+	Production string   `json:"Production"`
+	Website    string   `json:"Website"`
+	Response   string   `json:"Response"`
 }

--- a/pkg/omdb/omdb.go
+++ b/pkg/omdb/omdb.go
@@ -29,7 +29,7 @@ func New(apiKey string) Client {
 	}
 	return &Omdb{
 		ApiKey: apiKey,
-		Cache:  &MemoryCache{},
+		Cache:  NewMemoryCache(),
 		httpClient: &http.Client{
 			Timeout: 10 * time.Second,
 		},

--- a/pkg/omdb/omdb.go
+++ b/pkg/omdb/omdb.go
@@ -3,12 +3,13 @@ package omdb
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/sirupsen/logrus"
 	"net/http"
 	"net/url"
 	"regexp"
 	"sync"
 	"time"
+
+	"github.com/sirupsen/logrus"
 )
 
 type Omdb struct {
@@ -28,7 +29,7 @@ func New(apiKey string) Client {
 	}
 	return &Omdb{
 		ApiKey: apiKey,
-		Cache:  NewMemoryCache(),
+		Cache:  &MemoryCache{},
 		httpClient: &http.Client{
 			Timeout: 10 * time.Second,
 		},


### PR DESCRIPTION
Hi GaruGaru:

I made some changes

1. use sync.Map replace sync.RWMutex   
to make the map current safe, we can use sync.RWMutex , but I think use build-in sync.Map can write more consistent code.
there are many discussion [here](https://news.ycombinator.com/item?id=14557113) and [here](https://github.com/golang/go/issues/18177) 


2. extract `Rating` structure
I think maybe this can make code more readable