### PR TITLE
set log format for better debug

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -40,6 +40,12 @@ func New(conf config.CiakDaemonConfig, MediaDiscovery discovery.MediaDiscovery, 
 }
 
 func (daemon CiakDaemon) Start() error {
+	dateFormatter := &log.TextFormatter{
+		FullTimestamp:   true,
+		TimestampFormat: "2006-01-02 15:04:05.001 -0700 MST",
+	}
+	log.SetFormatter(dateFormatter)
+	log.SetReportCaller(true)
 	log.WithFields(log.Fields{
 		"workers":    daemon.Conf.Workers,
 		"queue_size": daemon.Conf.QueueSize,


### PR DESCRIPTION
Hi GaruGaru:

I modifid logrus setting for esay debug, now the log output format look like this
```sh
time="2020-11-28 17:50:32.011 +0800 CST" level=info msg="Ciak daemon started" func=github.com/GaruGaru/ciak/internal/daemon.CiakDaemon.Start file="D:/golang/src/github.com/brownchow/ciak/internal/daemon/daemon.go:52" queue_size=1000 workers=2
time="2020-11-28 17:50:32.011 +0800 CST" level=info msg="Ciak server started" func=github.com/GaruGaru/ciak/internal/server.CiakServer.Run file="D:/golang/src/github.com/brownchow/ciak/internal/server/server.go:46" bind="0.0.0.0:8082" version=0.0.2
```

`log.SetReportCaller(true)`  enable logrus prints the caller function file path and line number, this may make log huge, if this mess up log, we can disable it.
